### PR TITLE
bumped version of `angular-material` back from 1.1.0 to 1.0.2, as bef…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "angular-aria": "~1.4.8",
     "angularjs-socialshare": "2.3.11",
     "font-awesome": "~4.4.0",
-    "angular-material": "1.1.0",
+    "angular-material": "1.0.2",
     "bootstrap": "3.3.6",
     "angular-slick": "~0.2.1",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
…ore. We don't need the material design input options of 1.1.0 any more, and it broke the image widths on the car listing page